### PR TITLE
feat: add support for external auth

### DIFF
--- a/buildarr_sonarr/config/general.py
+++ b/buildarr_sonarr/config/general.py
@@ -39,6 +39,7 @@ class AuthenticationMethod(BaseEnum):
     none = "none"
     basic = "basic"
     form = "forms"
+    external = "external"
 
 
 class CertificateValidation(BaseEnum):
@@ -188,7 +189,7 @@ class SecurityGeneralSettings(GeneralSettings):
     Sonarr instance security (authentication) settings.
     """
 
-    authentication: AuthenticationMethod = AuthenticationMethod.none
+    authentication: AuthenticationMethod = AuthenticationMethod.external
     """
     Authentication method for logging into Sonarr.
     By default, do not require authentication.
@@ -198,6 +199,15 @@ class SecurityGeneralSettings(GeneralSettings):
     * `none` - No authentication
     * `basic` - Authentication using HTTP basic auth (browser popup)
     * `form` - Authentication using a login page
+    * `external` - External authentication using a reverse proxy
+
+    !!! warning
+
+        When the authentication method is set to `none` or `external`,
+        **authentication is disabled within Sonarr itself.**
+
+        **Make sure access to Sonarr is secured**, either by using a reverse proxy with
+        forward authentication configured, or not exposing Sonarr to the public Internet.
 
     Requires a restart of Sonarr to take effect.
     """

--- a/buildarr_sonarr/config/media_management.py
+++ b/buildarr_sonarr/config/media_management.py
@@ -33,6 +33,15 @@ from .types import SonarrConfigBase
 logger = getLogger(__name__)
 
 
+class ColonReplacement(BaseEnum):
+    delete = 0
+    dash = 1
+    space_dash = 2
+    space_dash_space = 3
+    smart = 4
+    custom = 5
+
+
 class MultiEpisodeStyle(BaseEnum):
     """
     Multi-episode style enumeration.
@@ -141,6 +150,20 @@ class SonarrMediaManagementSettingsConfig(SonarrConfigBase):
     Replace illegal characters within the file name.
 
     If set to `False`, Sonarr will remove them instead.
+    """
+
+    colon_replacement: ColonReplacement = ColonReplacement.delete
+    """
+    Replace or delete full colons (`:`) in release titles with alternative characters
+    when saving files.
+
+    Values:
+
+    * `delete` - Delete without replacement (e.g. `One:Two` → `OneTwo`) (default)
+    * `dash` - Replace with a dash (e.g. `One:Two` → `One-Two`)
+    * `smart` - Replace with a dash or space dash depending on name (e.g. `One:Two` → `One-Two`)
+    * `dash-space` - Replace with a dash and a space (e.g. `One:Two` → `One- Two`)
+    * `space-dash-space` - Replace with a space-separated dash (e.g. `One:Two` → `One - Two`)
     """
 
     standard_episode_format: NonEmptyStr = (
@@ -463,6 +486,7 @@ class SonarrMediaManagementSettingsConfig(SonarrConfigBase):
         ("season_folder_format", "seasonFolderFormat", {}),
         ("specials_folder_format", "specialsFolderFormat", {}),
         ("multiepisode_style", "multiEpisodeStyle", {}),
+        ("colon_replacement", "colonReplacementFormat", {}),
     ]
     _mediamanagement_remote_map: ClassVar[List[RemoteMapEntry]] = [
         # Folders


### PR DESCRIPTION
my sonarr instance had auth set to external, which when parsed by pydantic would cause a validation error. I copied over the code from `buildarr-radarr` nearly 1:1 and it fixed the issue for me.

also, is there a triage list of things that need to be fixed? the buildarr suite of tools is priceless to me, and I'm interested in trying to help out with your set of forks. thx for the hard work, has saved me a ton of hassle.