### PR TITLE
Updating quality definitions

### DIFF
--- a/buildarr_sonarr/config/general.py
+++ b/buildarr_sonarr/config/general.py
@@ -19,7 +19,8 @@ Sonarr plugin general settings configuration.
 from __future__ import annotations
 
 from ipaddress import IPv4Address
-from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Set, Tuple, Union
+from typing import (Any, ClassVar, Dict, List, Literal, Mapping, Optional, Set,
+                    Tuple, Union)
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import BaseEnum, NonEmptyStr, Port, SecretStr
@@ -39,6 +40,7 @@ class AuthenticationMethod(BaseEnum):
     none = "none"
     basic = "basic"
     form = "forms"
+    external = "external"
 
 
 class CertificateValidation(BaseEnum):

--- a/buildarr_sonarr/config/quality.py
+++ b/buildarr_sonarr/config/quality.py
@@ -188,6 +188,7 @@ class SonarrQualitySettingsConfig(SonarrConfigBase):
                         else None
                     ),
                     min=definition_json["minSize"],
+                    preferred=definition_json["preferredSize"],
                     max=definition_json.get("maxSize", None),
                 )
                 for definition_json in api_get(secrets, "/api/v3/qualitydefinition")


### PR DESCRIPTION
The -arr stack was updated to support quality definitions going up to 2000, instead of the previous max of 400. The TrASH guides were updated with this change, so this change allows buildarr-sonarr to support the new, higher value.